### PR TITLE
Remove gratuitous shebang from library files

### DIFF
--- a/pipkin/__main__.py
+++ b/pipkin/__main__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 MIT License
 

--- a/pipkin/proxy.py
+++ b/pipkin/proxy.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 MIT License
 


### PR DESCRIPTION
these non-executable files come with a shebang which is not used. Also, this causes problems when creating packages, rpm-linter does not like shebangs in these kinds of files.

See https://github.com/thonny/thonny/issues/2645